### PR TITLE
ci: add semantic release push permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -42,7 +42,7 @@ jobs:
       contents: write
       packages: write
     concurrency:
-      group: release
+      group: release-${{ github.event.number || github.ref }}
     runs-on: ubuntu-latest
     needs:
       - code-quality
@@ -51,15 +51,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4.1.0
         with:
           cache: npm
           node-version: lts/*
-      - run: npm clean-install
+      - run: HUSKY=0 npm ci
       - name: Run semantic-release
         id: release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           npx semantic-release > semantic_release_output.txt || false
           cat semantic_release_output.txt
@@ -71,7 +73,7 @@ jobs:
   upload-docs:
     concurrency:
       # Only one release job at a time. Strictly sequential.
-      group: upload-docs
+      group: upload-docs-${{ github.event.number || github.ref }}
     runs-on: ubuntu-latest
     needs:
       - release
@@ -100,7 +102,7 @@ jobs:
       contents: write
       packages: write
     concurrency:
-      group: deploy-image
+      group: deploy-image-${{ github.event.number || github.ref }}
     runs-on: ubuntu-latest
     needs:
       - release


### PR DESCRIPTION
This pull request updates the github token for semantic release, allowing it to push to main while the ci isn't passing yet.